### PR TITLE
ci: run fabricator VLAB on toolbox changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+      pull-requests: write
+
+    outputs:
+      version: "${{ steps.version-gen.outputs.version }}"
 
     steps:
       - name: Checkout repository
@@ -86,12 +90,68 @@ jobs:
             exit 1
           fi
 
+      - name: Generate temp artifacts version
+        id: version-gen
+        env:
+          commit_sha: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          echo "version=v0-${commit_sha::9}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push temp artifacts
+        run: |
+          just --timestamp oci_repo=ghcr.io version="${{ steps.version-gen.outputs.version }}" push
+
+      - name: Comment on PR with temp artifacts version
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '🚀 Temp artifacts published: `${{ steps.version-gen.outputs.version }}` 🚀'
+            })
+
       - name: Setup tmate session for debug
         if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: 30
         with:
           limit-access-to-actor: true
+
+  vlab:
+    needs:
+      - test
+    uses: githedgehog/fabricator/.github/workflows/run-vlab.yaml@master
+    with:
+      skip: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:-vlab') }}
+      fabricatorref: master
+      prebuild: |
+        sed -i "s|Toolbox:[[:space:]]*\"[^\"]*\"|Toolbox: \"${{ needs.test.outputs.version }}\"|" pkg/fab/versions.go
+        go fmt pkg/fab/versions.go
+      fabricmode: spine-leaf
+      gateway: false
+      includeonie: false
+      buildmode: iso
+      vpcmode: l2vni
+      hybrid: false
+
+  vlabs:
+    runs-on: ubuntu-latest
+    needs:
+      - vlab
+    if: ${{ always() }}
+
+    steps:
+      - run: |
+          result="${{ needs.vlab.result }}"
+          if [[ $result == "success" || $result == "skipped" ]]; then
+            exit 0
+          else
+            exit 1
+          fi
 
   publish:
     runs-on: lab

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,9 +128,10 @@ jobs:
     with:
       skip: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:-vlab') }}
       fabricatorref: master
-      prebuild: |
-        sed -i "s|Toolbox:[[:space:]]*\"[^\"]*\"|Toolbox: \"${{ needs.test.outputs.version }}\"|" pkg/fab/versions.go
-        go fmt pkg/fab/versions.go
+      # Single-line with no literal double quotes: run-vlab's Inputs summary step
+      # echoes prebuild inside "..." and breaks on embedded quotes. Use GNU sed
+      # \x22 for the Go string's double quotes.
+      prebuild: sed -ri 's@^\s*Toolbox:.*@\t\tToolbox:\x20\x22${{ needs.test.outputs.version }}\x22,@' pkg/fab/versions.go && go fmt pkg/fab/versions.go
       fabricmode: spine-leaf
       gateway: false
       includeonie: false


### PR DESCRIPTION
Publish temp toolbox artifacts to ghcr.io under a v0-<sha9> tag and invoke fabricator's reusable run-vlab.yaml, patching the Toolbox version in pkg/fab/versions.go via prebuild so the VLAB exercises the proposed toolbox build

Closes #26.