### PR TITLE
bump iperf to 3.21

### DIFF
--- a/packages_build.sh
+++ b/packages_build.sh
@@ -20,7 +20,7 @@ apt-get update -y \
     "${BUILD_APT_PACKAGES[@]}" \
     && rm -rf /var/lib/apt/lists/*
 
-git clone --branch 3.20 https://github.com/esnet/iperf.git /tmp/iperf \
+git clone --branch 3.21 https://github.com/esnet/iperf.git /tmp/iperf \
     && cd /tmp/iperf \
     && ./configure \
     && make \


### PR DESCRIPTION
## Summary
- Upgrades iperf built in the toolbox image from 3.20 to 3.21 (https://github.com/esnet/iperf/releases/tag/3.21).

Follow-up to #25 (build iperf from source) and #27 (pin version). Stacked on top of #30 so the VLAB CI added there exercises the new iperf build.

## Test plan
- [ ] `test` job builds the toolbox image with iperf 3.21
- [ ] `vlab` job (from #30) boots and passes connectivity tests with the new toolbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)