### PR TITLE
ci: gate publish on vlab success

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,6 +159,7 @@ jobs:
     if: startsWith(github.event.ref, 'refs/tags/v') && github.event_name == 'push'
     needs:
       - test
+      - vlab
 
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- On tag pushes \`publish\` ran in parallel with \`vlab\` because it only depended on \`test\`. A regression caught by VLAB would not have prevented the release.
- Add \`vlab\` to \`publish.needs\` so a tagged release is only published when the VLAB run passes — same gating fabricator uses for its \`publish-release\` job.

## Test plan
- [ ] On a tag push, confirm \`publish\` waits for both \`test\` and \`vlab\` before starting.
- [ ] On non-tag pushes / PRs, behavior is unchanged (publish remains gated on the tag \`if\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)